### PR TITLE
Adding microbatching support and setting for RAW

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ Storm topologies are generally launched with "fat" jars (jar-with-dependencies),
 </plugin>
 ```
 
-### Storm 1.0 and below
+### Storm versions below 1.0
 
 Since package prefixes changed from `backtype.storm` to `org.apache.storm` in Storm 1.0 and above, you will need to get the storm-0.10 version of Bullet if
 your Storm cluster is still not at 1.0 or higher. You change your dependency to:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.yahoo.bullet</groupId>
     <artifactId>bullet-storm</artifactId>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>bullet-storm</name>
 

--- a/src/main/java/com/yahoo/bullet/BulletConfig.java
+++ b/src/main/java/com/yahoo/bullet/BulletConfig.java
@@ -45,6 +45,7 @@ public class BulletConfig extends Config {
     public static final String SPECIFICATION_MAX_DURATION = "rule.max.duration";
     public static final String AGGREGATION_DEFAULT_SIZE = "rule.aggregation.default.size";
     public static final String AGGREGATION_MAX_SIZE = "rule.aggregation.max.size";
+    public static final String RAW_AGGREGATION_MICRO_BATCH_SIZE = "rule.aggregation.raw.micro.batch.size";
 
     public static final String RECORD_INJECT_TIMESTAMP = "record.inject.timestamp.enable";
     public static final String RECORD_INJECT_TIMESTAMP_KEY = "record.inject.timestamp.key";

--- a/src/main/java/com/yahoo/bullet/Topology.java
+++ b/src/main/java/com/yahoo/bullet/Topology.java
@@ -152,6 +152,7 @@ public class Topology {
         Long maxDuration = (Long) config.get(BulletConfig.SPECIFICATION_MAX_DURATION);
         Long defaultSize = (Long) config.get(BulletConfig.AGGREGATION_DEFAULT_SIZE);
         Long maxSize = (Long) config.get(BulletConfig.AGGREGATION_MAX_SIZE);
+        Integer microBatchSize = ( (Number) config.get(BulletConfig.RAW_AGGREGATION_MICRO_BATCH_SIZE)).intValue();
         Integer tickInterval = ((Number) config.get(BulletConfig.TICK_INTERVAL_SECS)).intValue();
 
         builder.setSpout(TopologyConstants.DRPC_COMPONENT, new DRPCSpout(function), drpcSpoutParallelism)
@@ -202,6 +203,7 @@ public class Topology {
         stormConfig.put(BulletConfig.SPECIFICATION_MAX_DURATION, maxDuration);
         stormConfig.put(BulletConfig.AGGREGATION_DEFAULT_SIZE, defaultSize);
         stormConfig.put(BulletConfig.AGGREGATION_MAX_SIZE, maxSize);
+        stormConfig.put(BulletConfig.RAW_AGGREGATION_MICRO_BATCH_SIZE, microBatchSize);
 
         // Metrics
         Boolean enableMetrics = (Boolean) config.get(BulletConfig.TOPOLOGY_METRICS_ENABLE);

--- a/src/main/java/com/yahoo/bullet/Topology.java
+++ b/src/main/java/com/yahoo/bullet/Topology.java
@@ -152,7 +152,7 @@ public class Topology {
         Long maxDuration = (Long) config.get(BulletConfig.SPECIFICATION_MAX_DURATION);
         Long defaultSize = (Long) config.get(BulletConfig.AGGREGATION_DEFAULT_SIZE);
         Long maxSize = (Long) config.get(BulletConfig.AGGREGATION_MAX_SIZE);
-        Integer microBatchSize = ( (Number) config.get(BulletConfig.RAW_AGGREGATION_MICRO_BATCH_SIZE)).intValue();
+        Integer microBatchSize = ((Number) config.get(BulletConfig.RAW_AGGREGATION_MICRO_BATCH_SIZE)).intValue();
         Integer tickInterval = ((Number) config.get(BulletConfig.TICK_INTERVAL_SECS)).intValue();
 
         builder.setSpout(TopologyConstants.DRPC_COMPONENT, new DRPCSpout(function), drpcSpoutParallelism)

--- a/src/main/java/com/yahoo/bullet/operations/aggregations/GroupData.java
+++ b/src/main/java/com/yahoo/bullet/operations/aggregations/GroupData.java
@@ -156,6 +156,7 @@ public class GroupData implements Serializable {
                 record.setDouble(getResultName(operation), calculateAvg(value, operation.getField()));
                 break;
             case COUNT_FIELD:
+                // Internal use only for AVG. Not exposed.
                 break;
             case MIN:
             case MAX:
@@ -201,9 +202,10 @@ public class GroupData implements Serializable {
      * @return A reified object or null if not successful.
      */
     public static GroupData fromBytes(byte[] data) {
-        try {
+        try (
             ByteArrayInputStream bis = new ByteArrayInputStream(data);
             ObjectInputStream ois = new ObjectInputStream(bis);
+        ) {
             return (GroupData) ois.readObject();
         } catch (IOException | ClassNotFoundException | RuntimeException e) {
             log.error("Could not reify a GroupData from raw data {}", data);
@@ -219,11 +221,11 @@ public class GroupData implements Serializable {
      * @return the serialized byte[] or null if not successful.
      */
     public static byte[] toBytes(GroupData metric) {
-        try {
+        try (
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             ObjectOutputStream oos = new ObjectOutputStream(bos);
+        ) {
             oos.writeObject(metric);
-            oos.close();
             return bos.toByteArray();
         } catch (IOException | RuntimeException e) {
             log.error("Could not serialize given GroupData contents", metric.metrics);

--- a/src/main/java/com/yahoo/bullet/operations/aggregations/Raw.java
+++ b/src/main/java/com/yahoo/bullet/operations/aggregations/Raw.java
@@ -149,7 +149,6 @@ public class Raw implements Strategy {
             ObjectInputStream ois = new ObjectInputStream(bis)
         ) {
             return (List<BulletRecord>) ois.readObject();
-
         } catch (IOException | ClassNotFoundException | ClassCastException e) {
             log.error("Could not deserialize batch {}", batch);
             log.error("Exception was ", e);

--- a/src/main/java/com/yahoo/bullet/operations/aggregations/Raw.java
+++ b/src/main/java/com/yahoo/bullet/operations/aggregations/Raw.java
@@ -131,8 +131,8 @@ public class Raw implements Strategy {
 
     private byte[] write(List<BulletRecord> batch) {
         try (
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                ObjectOutputStream oos = new ObjectOutputStream(bos)
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(bos)
         ) {
             oos.writeObject(batch);
             return bos.toByteArray();
@@ -145,8 +145,8 @@ public class Raw implements Strategy {
 
     private List<BulletRecord> read(byte[] batch) {
         try (
-                ByteArrayInputStream bis = new ByteArrayInputStream(batch);
-                ObjectInputStream ois = new ObjectInputStream(bis)
+            ByteArrayInputStream bis = new ByteArrayInputStream(batch);
+            ObjectInputStream ois = new ObjectInputStream(bis)
         ) {
             return (List<BulletRecord>) ois.readObject();
 

--- a/src/main/java/com/yahoo/bullet/operations/aggregations/Strategy.java
+++ b/src/main/java/com/yahoo/bullet/operations/aggregations/Strategy.java
@@ -29,6 +29,7 @@ public interface Strategy {
     default boolean isMicroBatch() {
         return false;
     }
+
     /**
      * Consumes a single {@link BulletRecord} into the aggregation.
      *

--- a/src/main/resources/bullet_defaults.yaml
+++ b/src/main/resources/bullet_defaults.yaml
@@ -50,7 +50,7 @@ topology.tick.interval.secs: 5
 topology.join.bolt.error.tick.timeout: 3
 
 # This is the number of ticks for which a rule will be buffered past its expiry in order to wait for
-# aggregations to trickle in from the filter bolts.
+# aggregations to trickle in from the Filter Bolts.
 topology.join.bolt.rule.tick.timeout: 3
 
 # The default duration in milliseconds for a rule if one has not been specified.
@@ -64,6 +64,16 @@ rule.aggregation.default.size: 1
 
 # The maximum number of records that will be aggregated per rule. Anything greater will be clamped to this value.
 rule.aggregation.max.size: 30
+
+# The maximum number of records that will be collected in the Filter Bolt till it is emitted - i.e. a micro-batch.
+# Leaving this at 1 emits your raw aggregation records as soon as they are received in the Filter Bolt. This makes
+# your raw aggregation query run snappier if the total number of matched records across the Filter Bolts exceeds
+# the number of records your query is looking for but individually each Filter Bolt does not find enough records to
+# satisfy the query. Since the records are emitted immediately, the Join Bolt will terminate your query as soon
+# as the total records are received instead of waiting for the micro-batch size to be reached.
+# If you set this too high (for example, higher than the query size), you will wait the entire duration of the query,
+# and the number of ticks specified in topology.join.bolt.rule.tick.timeout.
+rule.aggregation.raw.micro.batch.size: 1
 
 # Enable logging meta information in the results. Configured metadata will be add to the meta section of the
 # results: {"meta": {}, "records": []}

--- a/src/test/java/com/yahoo/bullet/TestHelpers.java
+++ b/src/test/java/com/yahoo/bullet/TestHelpers.java
@@ -10,8 +10,13 @@ import com.google.gson.JsonParser;
 import com.yahoo.bullet.record.BulletRecord;
 import org.testng.Assert;
 
-import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 public class TestHelpers {
@@ -33,11 +38,34 @@ public class TestHelpers {
         Assert.assertEquals(first, second);
     }
 
-    public static byte[] getByteArray(BulletRecord record) {
-        try {
-            return record.getAsByteArray();
-        } catch (IOException ioe) {
-            throw new RuntimeException(ioe);
+    public static byte[] getListBytes(BulletRecord... records) {
+        List<BulletRecord> asList = new ArrayList<>();
+        for (BulletRecord record : records) {
+            asList.add(record);
+        }
+        return serialize(asList);
+    }
+
+    public static byte[] serialize(Object o) {
+        try (
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(bos);
+        ) {
+            oos.writeObject(o);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Object deserialize(byte[] o) {
+        try (
+                ByteArrayInputStream bis = new ByteArrayInputStream(o);
+                ObjectInputStream ois = new ObjectInputStream(bis);
+        ) {
+            return ois.readObject();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/com/yahoo/bullet/TestHelpers.java
+++ b/src/test/java/com/yahoo/bullet/TestHelpers.java
@@ -48,8 +48,8 @@ public class TestHelpers {
 
     public static byte[] serialize(Object o) {
         try (
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                ObjectOutputStream oos = new ObjectOutputStream(bos);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
         ) {
             oos.writeObject(o);
             return bos.toByteArray();
@@ -60,8 +60,8 @@ public class TestHelpers {
 
     public static Object deserialize(byte[] o) {
         try (
-                ByteArrayInputStream bis = new ByteArrayInputStream(o);
-                ObjectInputStream ois = new ObjectInputStream(bis);
+            ByteArrayInputStream bis = new ByteArrayInputStream(o);
+            ObjectInputStream ois = new ObjectInputStream(bis);
         ) {
             return ois.readObject();
         } catch (Exception e) {

--- a/src/test/java/com/yahoo/bullet/parsing/SpecificationTest.java
+++ b/src/test/java/com/yahoo/bullet/parsing/SpecificationTest.java
@@ -6,7 +6,6 @@
 package com.yahoo.bullet.parsing;
 
 import com.yahoo.bullet.BulletConfig;
-import com.yahoo.bullet.TestHelpers;
 import com.yahoo.bullet.operations.AggregationOperations.AggregationType;
 import com.yahoo.bullet.operations.FilterOperations.FilterType;
 import com.yahoo.bullet.record.BulletRecord;
@@ -20,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -34,6 +34,10 @@ import static org.mockito.Mockito.when;
 public class SpecificationTest {
     public static Stream<BulletRecord> makeStream(int count) {
         return IntStream.range(0, count).mapToObj(x -> RecordBox.get().getRecord());
+    }
+
+    public static ArrayList<BulletRecord> makeList(int count) {
+        return makeStream(count).collect(Collectors.toCollection(ArrayList::new));
     }
 
     public static int size(BulletRecord record) {
@@ -221,7 +225,7 @@ public class SpecificationTest {
         specification.configure(emptyMap());
         Assert.assertTrue(makeStream(Aggregation.DEFAULT_SIZE - 1).map(specification::filter).allMatch(x -> x));
         // Check that we only get the default number out
-        makeStream(Aggregation.DEFAULT_SIZE + 2).map(TestHelpers::getByteArray).forEach(specification::aggregate);
+        makeList(Aggregation.DEFAULT_SIZE + 2).forEach(specification::aggregate);
         Assert.assertEquals((Integer) specification.getAggregate().size(), Aggregation.DEFAULT_SIZE);
     }
 

--- a/src/test/java/com/yahoo/bullet/tracing/AggregationRuleTest.java
+++ b/src/test/java/com/yahoo/bullet/tracing/AggregationRuleTest.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import static com.yahoo.bullet.TestHelpers.getByteArray;
+import static com.yahoo.bullet.TestHelpers.getListBytes;
 import static com.yahoo.bullet.parsing.RuleUtils.getAggregationRule;
 import static com.yahoo.bullet.parsing.RuleUtils.makeAggregationRule;
 import static java.util.Collections.emptyMap;
@@ -62,7 +62,7 @@ public class AggregationRuleTest {
     public void testAggregationTime() {
         AggregationRule rule = getAggregationRule("{'aggregation' : {}}", emptyMap());
         long creationTime = rule.getStartTime();
-        byte[] record = getByteArray(new BulletRecord());
+        byte[] record = getListBytes(new BulletRecord());
         IntStream.range(0, Aggregation.DEFAULT_SIZE - 1).forEach((x) -> rule.consume(record));
         Assert.assertEquals(rule.getData().size(), Aggregation.DEFAULT_SIZE - 1);
         long lastAggregationTime = rule.getLastAggregationTime();
@@ -72,7 +72,7 @@ public class AggregationRuleTest {
     @Test
     public void testDefaultLimiting() {
         AggregationRule rule = getAggregationRule("{'aggregation' : {}}", emptyMap());
-        byte[] record = getByteArray(new BulletRecord());
+        byte[] record = getListBytes(new BulletRecord());
         IntStream.range(0, Aggregation.DEFAULT_SIZE - 1).forEach(x -> Assert.assertFalse(rule.consume(record)));
         Assert.assertTrue(rule.consume(record));
         Assert.assertEquals((Integer) rule.getData().size(), Aggregation.DEFAULT_SIZE);
@@ -81,7 +81,7 @@ public class AggregationRuleTest {
     @Test
     public void testCustomLimiting() {
         AggregationRule rule = getAggregationRule(makeAggregationRule(AggregationType.RAW, 10), emptyMap());
-        byte[] record = getByteArray(new BulletRecord());
+        byte[] record = getListBytes(new BulletRecord());
         IntStream.range(0, 9).forEach(x -> Assert.assertFalse(rule.consume(record)));
         Assert.assertTrue(rule.consume(record));
         Assert.assertEquals(rule.getData().size(), 10);
@@ -90,7 +90,7 @@ public class AggregationRuleTest {
     @Test
     public void testSizeUpperBound() {
         AggregationRule rule = getAggregationRule(makeAggregationRule(AggregationType.RAW, 1000), emptyMap());
-        byte[] record = getByteArray(new BulletRecord());
+        byte[] record = getListBytes(new BulletRecord());
         IntStream.range(0, Aggregation.DEFAULT_MAX_SIZE - 1).forEach(x -> Assert.assertFalse(rule.consume(record)));
         Assert.assertTrue(rule.consume(record));
         Assert.assertEquals((Integer) rule.getData().size(), Aggregation.DEFAULT_MAX_SIZE);
@@ -102,7 +102,7 @@ public class AggregationRuleTest {
         config.put(BulletConfig.AGGREGATION_MAX_SIZE, 200);
 
         AggregationRule rule = getAggregationRule(makeAggregationRule(AggregationType.RAW, 1000), config);
-        byte[] record = getByteArray(new BulletRecord());
+        byte[] record = getListBytes(new BulletRecord());
         IntStream.range(0, 199).forEach(x -> Assert.assertFalse(rule.consume(record)));
         Assert.assertTrue(rule.consume(record));
         Assert.assertEquals(rule.getData().size(), 200);

--- a/src/test/java/com/yahoo/bullet/tracing/FilterRuleTest.java
+++ b/src/test/java/com/yahoo/bullet/tracing/FilterRuleTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 
-import static com.yahoo.bullet.TestHelpers.getByteArray;
+import static com.yahoo.bullet.TestHelpers.getListBytes;
 import static com.yahoo.bullet.parsing.RuleUtils.getFilterRule;
 import static com.yahoo.bullet.parsing.RuleUtils.makeAggregationRule;
 import static com.yahoo.bullet.parsing.RuleUtils.makeProjectionFilterRule;
@@ -36,7 +36,7 @@ public class FilterRuleTest {
         RecordBox boxB = RecordBox.get().addMap("map_field", Pair.of("id", "23"));
         RecordBox expected = RecordBox.get().add("mid", "23");
         Assert.assertTrue(rule.consume(boxB.getRecord()));
-        Assert.assertEquals(rule.getData(), getByteArray(expected.getRecord()));
+        Assert.assertEquals(rule.getData(), getListBytes(expected.getRecord()));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class FilterRuleTest {
         RecordBox boxA = RecordBox.get().addMap("map_field", Pair.of("id", "23"));
         RecordBox expectedA = RecordBox.get().add("mid", "23");
         Assert.assertTrue(rule.consume(boxA.getRecord()));
-        Assert.assertEquals(rule.getData(), getByteArray(expectedA.getRecord()));
+        Assert.assertEquals(rule.getData(), getListBytes(expectedA.getRecord()));
 
         RecordBox boxB = RecordBox.get().addMap("map_field", Pair.of("id", "3"));
         Assert.assertFalse(rule.consume(boxB.getRecord()));
@@ -58,7 +58,7 @@ public class FilterRuleTest {
         RecordBox boxC = RecordBox.get().addMap("map_field", Pair.of("id", "1"));
         RecordBox expectedC = RecordBox.get().add("mid", "1");
         Assert.assertTrue(rule.consume(boxC.getRecord()));
-        Assert.assertEquals(rule.getData(), getByteArray(expectedC.getRecord()));
+        Assert.assertEquals(rule.getData(), getListBytes(expectedC.getRecord()));
     }
 
     @Test
@@ -66,9 +66,9 @@ public class FilterRuleTest {
         FilterRule rule = getFilterRule(makeAggregationRule(AggregationType.RAW, 2), emptyMap());
         RecordBox box = RecordBox.get();
         Assert.assertTrue(rule.consume(box.getRecord()));
-        Assert.assertEquals(rule.getData(), getByteArray(box.getRecord()));
+        Assert.assertEquals(rule.getData(), getListBytes(box.getRecord()));
         Assert.assertTrue(rule.consume(box.getRecord()));
-        Assert.assertEquals(rule.getData(), getByteArray(box.getRecord()));
+        Assert.assertEquals(rule.getData(), getListBytes(box.getRecord()));
         for (int i = 0; i < 10; ++i) {
             Assert.assertFalse(rule.consume(box.getRecord()));
             Assert.assertNull(rule.getData());
@@ -87,7 +87,7 @@ public class FilterRuleTest {
         RecordBox boxB = RecordBox.get().add("mid", "42");
 
         Assert.assertTrue(rule.consume(boxA.getRecord()));
-        Assert.assertEquals(rule.getData(), getByteArray(expectedA.getRecord()));
+        Assert.assertEquals(rule.getData(), getListBytes(expectedA.getRecord()));
 
         Assert.assertFalse(rule.consume(boxB.getRecord()));
         Assert.assertNull(rule.getData());
@@ -96,7 +96,7 @@ public class FilterRuleTest {
         Assert.assertNull(rule.getData());
 
         Assert.assertTrue(rule.consume(boxA.getRecord()));
-        Assert.assertEquals(rule.getData(), getByteArray(expectedA.getRecord()));
+        Assert.assertEquals(rule.getData(), getListBytes(expectedA.getRecord()));
 
         for (int i = 0; i < 10; ++i) {
             Assert.assertFalse(rule.consume(boxA.getRecord()));


### PR DESCRIPTION
This modifies the RAW aggregation to support micro-batches (previously it assumed a micro-batch of size 1). The size of the micro-batch is configurable but recommended to be left at 1 unless the amount of raw tuples being shuffled from Filter to Join Bolts becomes a problem.

Since it changes the interface of what the RAW aggregation emits, bumping the minor version.