### PR TITLE
Fix for distributions with no data and emit only strict JSON

### DIFF
--- a/src/main/java/com/yahoo/bullet/operations/aggregations/sketches/QuantileSketch.java
+++ b/src/main/java/com/yahoo/bullet/operations/aggregations/sketches/QuantileSketch.java
@@ -217,7 +217,7 @@ public class QuantileSketch extends Sketch {
 
     private static double[] getPoints(double start, double end, int numberOfPoints) {
         // We should have numberOfPoints >= 1 but just in case...
-        if  (numberOfPoints <= 1) {
+        if  (numberOfPoints <= 1 || start >= end) {
             return new double[] { start };
         }
 

--- a/src/main/java/com/yahoo/bullet/result/JSONFormatter.java
+++ b/src/main/java/com/yahoo/bullet/result/JSONFormatter.java
@@ -7,8 +7,12 @@ package com.yahoo.bullet.result;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
 
 public interface JSONFormatter {
+    JsonSerializer<Double> INVALID_DOUBLES = (item, type, context) -> item.isNaN() || item.isInfinite() ?
+                                                                      new JsonPrimitive(item.toString()) : new JsonPrimitive(item);
     Gson GSON = new GsonBuilder().serializeNulls().serializeSpecialFloatingPointValues().create();
 
     /**

--- a/src/main/java/com/yahoo/bullet/result/JSONFormatter.java
+++ b/src/main/java/com/yahoo/bullet/result/JSONFormatter.java
@@ -13,7 +13,7 @@ import com.google.gson.JsonSerializer;
 public interface JSONFormatter {
     JsonSerializer<Double> INVALID_DOUBLES = (item, type, context) -> item.isNaN() || item.isInfinite() ?
                                                                       new JsonPrimitive(item.toString()) : new JsonPrimitive(item);
-    Gson GSON = new GsonBuilder().serializeNulls().serializeSpecialFloatingPointValues().create();
+    Gson GSON = new GsonBuilder().serializeNulls().registerTypeAdapter(Double.class, INVALID_DOUBLES).create();
 
     /**
      * Returns a JSON string representation of object.

--- a/src/test/java/com/yahoo/bullet/TestHelpers.java
+++ b/src/test/java/com/yahoo/bullet/TestHelpers.java
@@ -34,7 +34,7 @@ public class TestHelpers {
         JsonParser parser = new JsonParser();
         JsonElement first = parser.parse(actual);
         JsonElement second = parser.parse(expected);
-        Assert.assertTrue(first.equals(second), "Actual: " + first + " Expected: " + second);
+        Assert.assertEquals(first, second, "Actual: " + first + " Expected: " + second);
     }
 
     public static void assertApproxEquals(double actual, double expected) {

--- a/src/test/java/com/yahoo/bullet/TestHelpers.java
+++ b/src/test/java/com/yahoo/bullet/TestHelpers.java
@@ -34,7 +34,7 @@ public class TestHelpers {
         JsonParser parser = new JsonParser();
         JsonElement first = parser.parse(actual);
         JsonElement second = parser.parse(expected);
-        Assert.assertEquals(first, second, "Actual: " + first + " Expected: " + second);
+        Assert.assertTrue(first.equals(second), "Actual: " + first + " Expected: " + second);
     }
 
     public static void assertApproxEquals(double actual, double expected) {

--- a/src/test/java/com/yahoo/bullet/result/ClipTest.java
+++ b/src/test/java/com/yahoo/bullet/result/ClipTest.java
@@ -24,6 +24,10 @@ public class ClipTest {
         return "{\"meta\": {}, \"records\": " + results + "}";
     }
 
+    public static String makeJSON(String meta, String records) {
+        return "{\"meta\": " + meta + ", \"records\": " + records + "}";
+    }
+
     @Test
     public void testEmptyRecord() {
         assertJSONEquals(new Clip().asJSON(), EMPTY_RESULT);
@@ -70,14 +74,16 @@ public class ClipTest {
     }
 
     @Test
-    public void testSpecialValues() {
+    public void testInvalidDoubles() {
         BulletRecord record = new RecordBox().addNull("field").add("plus_inf", Double.POSITIVE_INFINITY)
                                              .add("neg_inf", Double.NEGATIVE_INFINITY)
                                              .add("not_a_number", Double.NaN)
                                              .getRecord();
 
-        assertJSONEquals(Clip.of(record).asJSON(),
-                         makeJSON("[{'field': null, 'plus_inf': 'Infinity', 'neg_inf': '-Infinity', " +
-                                  "'not_a_number': 'NaN'}]"));
+        Metadata metadata = new Metadata().add("foo", Double.POSITIVE_INFINITY).add("bar", Double.NaN).add("baz", Double.NEGATIVE_INFINITY);
+
+        assertJSONEquals(Clip.of(record).add(metadata).asJSON(),
+                         makeJSON("{'foo': 'Infinity', 'baz': '-Infinity', 'bar': 'NaN'}",
+                                 "[{'field': null, 'plus_inf': 'Infinity', 'neg_inf': '-Infinity', 'not_a_number': 'NaN'}]"));
     }
 }


### PR DESCRIPTION
If a Distribution aggregation matched no data, it currently threw an exception (range generation was bad). This was handled and the user saw the no results scenario (records empty) but the metadata contained this error. While the behavior is still acceptable, this fixes that issue and always returns the result from the Sketch (which was one of ```Double.{NEGATIVE_INFINITY, POSITIVE_INFINITY or NAN}```).

We were also forcing Gson to emit these invalid Doubles as Javascript equivalent but the JSON spec does not officially support them. This fixes it to convert these bad doubles to Strings instead.